### PR TITLE
second parameter name

### DIFF
--- a/WindowsAPI.cs
+++ b/WindowsAPI.cs
@@ -224,7 +224,7 @@ namespace AeroShot
         internal static extern void DwmGetColorizationParameters(out DWM_COLORIZATION_PARAMS parameters);
 
         [DllImport("dwmapi.dll", EntryPoint = "#131", PreserveSig = false)]
-        internal static extern void DwmSetColorizationParameters(ref DWM_COLORIZATION_PARAMS parameters, bool unknown);
+        internal static extern void DwmSetColorizationParameters(ref DWM_COLORIZATION_PARAMS parameters, bool isTemporary);
 
         [DllImport("dwmapi.dll", PreserveSig = false)]
         public static extern void DwmEnableComposition(bool bEnable);


### PR DESCRIPTION
if the second parameter is false(0), it saves the changed colorization parameters to the registry, and if true(1), it does not save it to registry and it will be discarded when dwm is restarted